### PR TITLE
Fix: improve version lookup logic and clarify PyPI mirror in warning message

### DIFF
--- a/src/showmereqs/config/mapping
+++ b/src/showmereqs/config/mapping
@@ -1065,6 +1065,7 @@ tastypie:django_tastypie
 teamcity:teamcity_messages
 telebot:pyTelegramBotAPI
 telegram:python-telegram-bot
+tap:typed-argument-parser
 tempita:Tempita
 tenjin:Tenjin
 termstyle:python_termstyle

--- a/src/showmereqs/package_info.py
+++ b/src/showmereqs/package_info.py
@@ -19,9 +19,9 @@ class PackageInfo:
     package_name: Optional[str] = None
 
     def __post_init__(self):
-        self.version = self._get_local_version()
-
         self.package_name = self._get_package_name_from_mapping()
+
+        self.version = self._get_local_version()
 
         if self.package_name is None:
             json_info = self._get_pypi_json(self.import_name, self.pypi_server)
@@ -59,6 +59,9 @@ class PackageInfo:
             version = importlib.metadata.version(self.import_name)
             return version
         except importlib.metadata.PackageNotFoundError:
+            if self.package_name is not None:
+                version = importlib.metadata.version(self.package_name)
+                return version
             return None
 
     def _get_package_name_from_mapping(self, special_mapping: dict[str, str] = None):

--- a/src/showmereqs/package_info.py
+++ b/src/showmereqs/package_info.py
@@ -80,4 +80,4 @@ class PackageInfo:
             else:
                 return None
         except Exception as e:
-            print(f"Warning: Error checking {package_name} on PyPI: {e}")
+            print(f"Warning: Error checking {package_name} on {pypi_api}: {e}")


### PR DESCRIPTION
This PR refines package version retrieval and improves log clarity:

* **Enhanced version lookup:**
  Get `package_name` before fetching the version.
  When `import_name` and `package_name` differ, the code now first tries to get the version by `import_name`, and if that fails, falls back to `package_name`.

* **Improved warning message:**
  Updated the `_get_pypi_json` log output to display the actual `{pypi_api}` being used instead of the fixed text “PyPI”, ensuring correct source information when using mirrors such as Aliyun or USTC.

These changes make dependency resolution more robust and mirror-friendly.
